### PR TITLE
add roomname variable to templating

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -18,6 +18,7 @@ domain: "server.tld"
 # %bl = hyperlink to original post 
 # %bu = display name of the user who caused the original post
 # %bi = link to the cross-poster user ID
+# %rn = room name of originating message
 # \n = linebreak
 template: "[%on](%ol): %m \n\n ([%e](%bl) by [%bu](%bi))"
 

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.1.0
 id: org.rosi-kessel.reacjibot
-version: 1.8.3
+version: 1.8.4
 license: MIT
 modules:
   - reacjibot

--- a/reacjibot/bot.py
+++ b/reacjibot/bot.py
@@ -123,6 +123,9 @@ class ReacjiBot(Plugin):
                         continue
                 # displayname: the display name for the original poster
                 displayname = await self.client.get_displayname(source_evt.sender)
+                # name of the room original message was posted in
+                roomnamestate = await self.client.get_state_event(source_evt.room_id, 'm.room.name')
+                roomname = roomnamestate['name']
                 # userlink: a hyperlink to the original poster's user ID
                 userlink = MatrixURI.build(source_evt.sender)
                 # body: the contents of the message to be cross-posted
@@ -143,6 +146,7 @@ class ReacjiBot(Plugin):
                 message = message.replace('%bl',str(xmessage))
                 message = message.replace('%bu',xdisplayname)
                 message = message.replace('%bi',str(xuserlink))
+                message = message.replace('%rn',str(roomname))
                 self.debug and self.log.debug(f"posting {message} to {target_id}")
                 await self.client.send_markdown(target_id,message)
                 # add post to the crossposted dictionary to avoid future reposts


### PR DESCRIPTION
this allows you to do something like:

```yaml
template: "[in %rn](%bl), [%on](%ol) said:\n\n%m"
```

which will look like:

```
in Off Topic, Steve said:

hello world!
```

where `Off Topic` is a hyperlink back to the original message.